### PR TITLE
[outpolic-YSR] 중복된 파일 제거

### DIFF
--- a/outpolic/src/main/resources/logback-spring.xml
+++ b/outpolic/src/main/resources/logback-spring.xml
@@ -45,7 +45,7 @@
     </appender> -->
 	
 	<!-- 프로젝트 패키지 안 클래스에 설정된 로그 출력 -->
-	<logger name="ks55team02" level="INFO" additivity="false">
+	<logger name="outpolic" level="INFO" additivity="false">
 		<appender-ref ref="STDOUT" />
 	</logger>
 


### PR DESCRIPTION
detail : system.file.mapper와 user.file.mapper가 빈에 동일한 이름으로 저장되어 있어서 user.file 패키지를 삭제했습니당